### PR TITLE
must specify the vignette engine explicitly

### DIFF
--- a/vignettes/ChemoSpec.Rnw
+++ b/vignettes/ChemoSpec.Rnw
@@ -2,6 +2,7 @@
 %\VignetteDepends{chemometrics, robustbase, RColorBrewer, plyr, pcaPP, mvtnorm, mvoutlier, pls, lattice, grid, rgl, R.utils, mclust, mvbutils, sna, knitr}
 %\VignetteKeywords{multivariate}
 %\VignettePackage{ChemoSpec}
+%\VignetteEngine{knitr::knitr}
 
 %%%% This is a knitr not sweave document.
 


### PR DESCRIPTION
as documented in the R-exts manual: http://cran.r-project.org/doc/manuals/r-release/R-exts.html#Non_002dSweave-vignettes

currently CRAN has disabled building your vignettes perhaps due to this reason: http://cran.r-project.org/web/checks/check_results_ChemoSpec.html
