### PR TITLE
Added plotly graphics mode in aovPCAscores function + minor additions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,26 +1,29 @@
 
 # ChemoSpec 6.0.0 2021-07-26
 ## Significant Changes
-* Courtesy GSOC and Tejasvi Gupta, the following plotting functions gain the ability to produce either `base` graphics or `ggplot2` graphics:
+* Courtesy GSOC and Tejasvi Gupta, the following plotting functions gain the ability to produce either `base` graphics or `ggplot2` or `plotly` graphics:
   - `plotSpectra`
   - `surveySpectra`
   - `surveySpectra2`
   - `loopThruSpectra` (which has been renamed to `reviewAllSpectra`)
   - `plotScores`
   - `plotScree` (actually in `ChemoSpecUtils`)
-  - `plotLoadings`
+  - `plotLoadings` (not implemented in `plotly` graphics)
   - `plot2Loadings`
   - `sPlotSpectra`
   - `pcaDiag`
   - `sampleDist`
   - `aovPCAscores`
-  - `aovPCAloadings`
+  - `aovPCAloadings`(not implemented in `plotly` graphics)
 
 The `ggplot2` graphics output are generally similar in layout and spirit to the `base` graphics output, but significant improvements have been made in labeling data points using the `ggrepel` package.  And of course the `ggplot2` graphics can be modified after creation through the usual mechanisms.
 * The graphics output options can be chosen by `options(ChemoSpecGraphics = "option")`.
 * See the details in new help file `?GraphicsOptions`.
 * `loopThruSpectra` has been renamed `reviewAllSpectra` to better reflect what it does under the new graphics options.
 * `plotSpectra`, when using `base` graphics, now positions the sample names by a different mechanism, but gives a similar result.
+
+The `plotly` graphics output are interactive plots which can be used for better understanding the data. `plotly` provides tools such as zoom, interactive labels and custom positioning which are very useful. 
+* `plotLoadings` and `aovPCAscores` are yet to be implemented in `plotly`.
 
 # ChemoSpec 5.3.21 2021-07-05
 ## Misc.

--- a/R/GraphicsOptions.R
+++ b/R/GraphicsOptions.R
@@ -3,14 +3,14 @@
 #'
 #' In \code{ChemoSpec}, the user may chose from the following graphics output options:
 #' \itemize{
-#'   \item \code{base} graphics, the default (also the only style from the early days of \code{ChemoSpec} through version 5).
-#'   \item \code{ggplot2} graphics.
+#'   \item \code{base} graphics (also the only style from the early days of \code{ChemoSpec} through version 5).
+#'   \item \code{ggplot2} graphics ,the default.
 #'   \item \code{plotly} graphics.
 #' }
 #'
 #' Here's how it works:
 #' \itemize{
-#'   \item Upon starting \code{ChemoSpec} the graphics output mode is set to \code{base}.
+#'   \item Upon starting \code{ChemoSpec} the graphics output mode is set to \code{ggplot2}.
 #'   \item To see the current value, do \code{\link[ChemoSpecUtils]{chkGraphicsOpt}}.  If by some chance the
 #'         value is corrupted it will be set to \code{base}.
 #'   \item To change the graphics output mode, do \code{options(ChemoSpecGraphics = 'option')},
@@ -25,11 +25,11 @@
 #'         used here via the usual \code{ggplot2} methods.  A few simple examples are given below
 #'         but this is not the place for a \code{ggplot2} tutorial.  See \url{https://ggplot2.tidyverse.org/}
 #'         for all things \code{ggplot2}.
-#'   \item \code{plotly} graphics is an interative graphics option where the user can interact with the plot and
-#'         use the tools provided by plotly package.
+#'   \item \code{plotly} graphics is an interactive graphics option where the user can
+#'         use the tools provided by \code{plotly} package and interact with the plot.
 #' }
 #'
-#' @author Bryan A. Hanson, DePauw University.
+#' @author Bryan A. Hanson, DePauw University, Tejasvi Gupta.
 #'
 #' @keywords utilities
 #'

--- a/R/aovPCAscores.R
+++ b/R/aovPCAscores.R
@@ -76,5 +76,10 @@ aovPCAscores <- function(spectra, so, submat = 1, ellipse = "none", tol = "none"
     p <- plotScores(spectra, so, ellipse = ellipse, tol = tol, use.sym = use.sym, leg.loc = leg.loc, ...)
     return(p)
   }
-
+  
+  if (go == "plotly") {
+    so <- so[[submat]] # need to force evaluation for some reason (do.call is downstream)
+    p <- plotScores(spectra, so, ellipse = ellipse, tol = tol, use.sym = use.sym, leg.loc = leg.loc, ...)
+    return(p)
+  }
 }

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -7,5 +7,5 @@
   packageStartupMessage("\nAs of version 6, ChemoSpec offers new graphics output options")
   packageStartupMessage("For details, please see ?GraphicsOptions")
   packageStartupMessage("\nThe ChemoSpec graphics option is set to 'ggplot2'")
-  packageStartupMessage("To change it, do\n\toptions(ChemoSpecGraphics = 'option'),\n\twhere 'option' is one of 'base' or 'ggplot2' or'plotly' ")
+  packageStartupMessage("To change it, do\n\toptions(ChemoSpecGraphics = 'option'),\n\twhere 'option' is one of 'base' or 'ggplot2' or'plotly'.")
 }

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -2,10 +2,10 @@
 #' @noRd
 #'
 .onAttach <- function(libname, pkgname) {
-  options(ChemoSpecGraphics = "base")
+  options(ChemoSpecGraphics = "ggplot2")
 
   packageStartupMessage("\nAs of version 6, ChemoSpec offers new graphics output options")
   packageStartupMessage("For details, please see ?GraphicsOptions")
-  packageStartupMessage("\nThe ChemoSpec graphics option is set to 'base'")
-  packageStartupMessage("To change it, do\n\toptions(ChemoSpecGraphics = 'option'),\n\twhere 'option' is one of 'base' or 'ggplot2'")
+  packageStartupMessage("\nThe ChemoSpec graphics option is set to 'ggplot2'")
+  packageStartupMessage("To change it, do\n\toptions(ChemoSpecGraphics = 'option'),\n\twhere 'option' is one of 'base' or 'ggplot2' or'plotly' ")
 }

--- a/man/GraphicsOptions.Rd
+++ b/man/GraphicsOptions.Rd
@@ -7,15 +7,15 @@
 \description{
 In \code{ChemoSpec}, the user may chose from the following graphics output options:
 \itemize{
-  \item \code{base} graphics, the default (also the only style from the early days of \code{ChemoSpec} through version 5).
-  \item \code{ggplot2} graphics.
+  \item \code{base} graphics (also the only style from the early days of \code{ChemoSpec} through version 5).
+  \item \code{ggplot2} graphics ,the default.
   \item \code{plotly} graphics.
 }
 }
 \details{
 Here's how it works:
 \itemize{
-  \item Upon starting \code{ChemoSpec} the graphics output mode is set to \code{base}.
+  \item Upon starting \code{ChemoSpec} the graphics output mode is set to \code{ggplot2}.
   \item To see the current value, do \code{\link[ChemoSpecUtils]{chkGraphicsOpt}}.  If by some chance the
         value is corrupted it will be set to \code{base}.
   \item To change the graphics output mode, do \code{options(ChemoSpecGraphics = 'option')},
@@ -30,8 +30,8 @@ What you can do with your plots:
         used here via the usual \code{ggplot2} methods.  A few simple examples are given below
         but this is not the place for a \code{ggplot2} tutorial.  See \url{https://ggplot2.tidyverse.org/}
         for all things \code{ggplot2}.
-  \item \code{plotly} graphics is an interative graphics option where the user can interact with the plot and
-        use the tools provided by plotly package.
+  \item \code{plotly} graphics is an interactive graphics option where the user can
+        use the tools provided by \code{plotly} package and interact with the plot.
 }
 }
 \examples{
@@ -69,6 +69,6 @@ options(ChemoSpecGraphics = "base") # turn off for later examples/tests
 
 }
 \author{
-Bryan A. Hanson, DePauw University.
+Bryan A. Hanson, DePauw University, Tejasvi Gupta.
 }
 \keyword{utilities}

--- a/man/plot2Loadings.Rd
+++ b/man/plot2Loadings.Rd
@@ -53,7 +53,8 @@ pca <- c_pcaSpectra(SrE.IR)
 myt <- expression(bolditalic(Serenoa) ~ bolditalic(repens) ~ bold(IR ~ Spectra))
 res <- plot2Loadings(SrE.IR, pca,
   main = myt,
-  loads = c(1, 2), tol = 0.001)
+  loads = c(1, 2), tol = 0.001
+)
 }
 \seealso{
 See \code{\link{plotLoadings}} to plot one loading against the


### PR DESCRIPTION
Added plotly graphics mode in `aovPCAscores` function, updated news.md and graphicOptions.R to include `plotly` graphics mode. Updated default graphics mode as `ggplot2` and some minor fixes.